### PR TITLE
Better args

### DIFF
--- a/ScrapPackedExplorerCli/CliApp.cs
+++ b/ScrapPackedExplorerCli/CliApp.cs
@@ -61,10 +61,16 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
 
         private static int DisplayHelp<T>(ParserResult<T> result, IEnumerable<Error> errors)
         {
+            string usage = "\r\nUSAGE: " +
+                "\r\n  ScrapPackedExplorerCli.exe <path-to-packed-file> <subcommand> <options>\r\n" +
+                "\r\nEXAMPLE: " +
+                "\r\n  ScrapPackedExplorerCli.exe example.packed list -xzq filename.txt -l tree";
+
             var helpText = HelpText.AutoBuild(result, h =>
             {
                 h.AddEnumValuesToHelpText = true;
                 h.AutoHelp = true;
+                h.AddPreOptionsLine(usage);
                 return h;
             });
 

--- a/ScrapPackedExplorerCli/CliApp.cs
+++ b/ScrapPackedExplorerCli/CliApp.cs
@@ -64,13 +64,14 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
             string usage = "\r\nUSAGE: " +
                 "\r\n  ScrapPackedExplorerCli.exe <path-to-packed-file> <subcommand> <options>\r\n" +
                 "\r\nEXAMPLE: " +
-                "\r\n  ScrapPackedExplorerCli.exe example.packed list -xzq filename.txt -l tree";
+                "\r\n  ScrapPackedExplorerCli.exe example.packed list -xzq filename.txt -l tree\r\n" +
+                "\r\nOPTIONS:";
 
             var helpText = HelpText.AutoBuild(result, h =>
             {
                 h.AddEnumValuesToHelpText = true;
                 h.AutoHelp = true;
-                h.AddPreOptionsLine(usage);
+                h.AddPreOptionsText(usage);
                 h.OptionComparison = orderOnValues;
                 return h;
             });

--- a/ScrapPackedExplorerCli/CliApp.cs
+++ b/ScrapPackedExplorerCli/CliApp.cs
@@ -18,22 +18,27 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
                 with.CaseInsensitiveEnumValues = true;
             }).ParseArguments<AddOptions, RemoveOptions, RenameOptions, ExtractOptions, ListOptions>(args);
 
+            return result.MapResult(
+                (AddOptions     options) => RunAdd(options),
+                (RemoveOptions  options) => RunRemove(options),
+                (RenameOptions  options) => RunRename(options),
+                (ExtractOptions options) => RunExtract(options),
+                (ListOptions    options) => RunList(options),
+                errors => DisplayHelp(result, errors)
+            );
+        }
+
+        private static int DisplayHelp<T>(ParserResult<T> result, IEnumerable<Error> errors)
+        {
             var helpText = HelpText.AutoBuild(result, h =>
             {
                 h.AddEnumValuesToHelpText = true;
+                h.AutoHelp = true;
                 return h;
-            }, e => e);
+            });
 
-            return result.MapResult(
-                    (AddOptions options) => RunAdd(options),
-                    (RemoveOptions options) => RunRemove(options),
-                    (RenameOptions options) => RunRename(options),
-                    (ExtractOptions options) => RunExtract(options),
-                    (ListOptions options) => RunList(options),
-                    errors => {
-                        Console.Error.WriteLine(helpText);
-                        return 1;
-                    });
+            Console.Error.WriteLine(helpText);
+            return 1;
         }
 
         private int RunAdd(AddOptions options)

--- a/ScrapPackedExplorerCli/CliApp.cs
+++ b/ScrapPackedExplorerCli/CliApp.cs
@@ -1,5 +1,6 @@
 ﻿using ch.romibi.Scrap.Packed.PackerLib;
 using CommandLine;
+using CommandLine.Text;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,15 +12,28 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
     {
         public int Run(string[] args)
         {
-            // todo: make proper parser instanse to configure case insensitivity for enums and better help text
-            return Parser.Default.ParseArguments<AddOptions, RemoveOptions, RenameOptions, ExtractOptions, ListOptions>(args)
-                .MapResult(
+            var result = new Parser(with =>
+            {
+                with.HelpWriter = null;
+                with.CaseInsensitiveEnumValues = true;
+            }).ParseArguments<AddOptions, RemoveOptions, RenameOptions, ExtractOptions, ListOptions>(args);
+
+            var helpText = HelpText.AutoBuild(result, h =>
+            {
+                h.AddEnumValuesToHelpText = true;
+                return h;
+            }, e => e);
+
+            return result.MapResult(
                     (AddOptions options) => RunAdd(options),
                     (RemoveOptions options) => RunRemove(options),
                     (RenameOptions options) => RunRename(options),
                     (ExtractOptions options) => RunExtract(options),
                     (ListOptions options) => RunList(options),
-                    errors => 1);
+                    errors => {
+                        Console.Error.WriteLine(helpText);
+                        return 1;
+                    });
         }
 
         private int RunAdd(AddOptions options)

--- a/ScrapPackedExplorerCli/CliApp.cs
+++ b/ScrapPackedExplorerCli/CliApp.cs
@@ -64,7 +64,7 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
             string usage = "\r\nUSAGE: " +
                 "\r\n  ScrapPackedExplorerCli.exe <path-to-packed-file> <subcommand> <options>\r\n" +
                 "\r\nEXAMPLE: " +
-                "\r\n  ScrapPackedExplorerCli.exe example.packed list -xzq filename.txt -l tree\r\n" +
+                "\r\n  ScrapPackedExplorerCli.exe example.packed list -osq filename.txt -l tree\r\n" +
                 "\r\nOPTIONS:";
 
             var helpText = HelpText.AutoBuild(result, h =>

--- a/ScrapPackedExplorerCli/CliApp.cs
+++ b/ScrapPackedExplorerCli/CliApp.cs
@@ -71,12 +71,21 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
                 h.AddEnumValuesToHelpText = true;
                 h.AutoHelp = true;
                 h.AddPreOptionsLine(usage);
+                h.OptionComparison = orderOnValues;
                 return h;
             });
 
             Console.Error.WriteLine(helpText);
             return 1;
         }
+
+        private static Comparison<ComparableOption> orderOnValues = (ComparableOption attr1, ComparableOption attr2) =>
+        {
+            if (attr1.IsValue)
+                return -1;
+            else
+                return 1;
+        };
 
         private int RunAdd(AddOptions options)
         {

--- a/ScrapPackedExplorerCli/CliOptions.cs
+++ b/ScrapPackedExplorerCli/CliOptions.cs
@@ -87,9 +87,6 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
 
         [Option('x', "show-file-offset", Required = false, Default = false, HelpText = "Show files offsets")]
         public bool ShowFileOffset { get; set; }
-
-        // todo: make custom helper to make better help screen
-        // note: https://github.com/commandlineparser/commandline/wiki/HelpText-Configuration
     }
 
     [Flags]

--- a/ScrapPackedExplorerCli/CliOptions.cs
+++ b/ScrapPackedExplorerCli/CliOptions.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using CommandLine.Text;
 using System;
 using System.Collections.Generic;
 
@@ -6,10 +7,9 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
 {
     abstract class BaseOptions
     {
-        [Option('p', "packedFile",  Required = true, HelpText = "The .packed file to use as basis")]
+        [Value(0, Required = true, MetaName = "Packed file", HelpText = "The .packed file to use as basis")]
         public string packedFile { get; set; }
     }
-
     abstract class ModifyingOptions : BaseOptions
     {
         [Option('o', "outputPackedFile", Required = false, Default = "", HelpText = "Where to store the new .packed file. Modify input if not provided.")]
@@ -100,5 +100,4 @@ namespace ch.romibi.Scrap.Packed.Explorer.Cli
         Tree = 0x2,
         Name = 0x3
     }
-
 }

--- a/ScrapPackedTests/TestCliApp.cs
+++ b/ScrapPackedTests/TestCliApp.cs
@@ -38,7 +38,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             File.Copy(@"TestData\empty.packed", @"TestResults\TestAdd\packedFile.packed", true);
 
             // add file new
-            CheckRunCompareFile(new[] {"add", "--packedFile", @"TestResults\TestAdd\packedFile.packed",
+            CheckRunCompareFile(new[] {"add", @"TestResults\TestAdd\packedFile.packed",
                 "--sourcePath", @"TestData\examplefile1.txt",
                 "--packedPath", @"file.txt" },
                 @"TestData\TestReferenceFiles\TestAdd\addFileNew.packed",
@@ -47,7 +47,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             );
 
             // add file existing to root
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed",
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed",
                 "--sourcePath", @"TestData\examplefile1.txt" },
                 @"TestData\TestReferenceFiles\TestAdd\addFileExistingToRoot.packed",
                 @"TestResults\TestAdd\packedFile.packed",
@@ -55,7 +55,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             );
 
             // add file existing
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed",
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed",
                 "--sourcePath", @"TestData\examplefile1.txt",
                 "--packedPath", "folder/file.txt" },
                 @"TestData\TestReferenceFiles\TestAdd\addFileExisting.packed",
@@ -63,7 +63,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "Add file to existing");
 
             // add file replace
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed", 
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed", 
                 "--sourcePath", @"TestData\examplefile3.txt",
                 "--packedPath", "folder/file.txt" },
                 @"TestData\TestReferenceFiles\TestAdd\addFileReplace.packed",
@@ -71,7 +71,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "Add file to existing and replace");
 
             // add file different output
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed",
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed",
                 "--sourcePath", @"TestData\examplefile1.txt",
                 "--packedPath", "folder/file.txt",
                 "--outputPackedFile", @"TestResults\TestAdd\newPackedFile.packed" },
@@ -87,21 +87,21 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
         public void TestRunAddFolder()
         {
             // add folder new
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed",
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed",
                 "--sourcePath", @"TestData\exampleFolder1\" },
                 @"TestData\TestReferenceFiles\TestAdd\addFolderNew.packed",
                 @"TestResults\TestAdd\packedFile.packed",
                 "Add folder to new");
 
             // add folder existing root
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed",
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed",
                 "--sourcePath", @"TestData\exampleFolder2\" },
                 @"TestData\TestReferenceFiles\TestAdd\addFolderExistingToRoot.packed",
                 @"TestResults\TestAdd\packedFile.packed",
                 "Add folder to existing to root");
 
             // add folder existing subfolder
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed", 
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed", 
                 "--sourcePath", @"TestData\exampleFolder1\",
                 "--packedPath", "subfolder/" },
                 @"TestData\TestReferenceFiles\TestAdd\addFolderExistingToSubfolder.packed",
@@ -109,7 +109,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "Add folder to existing to subfolder");
 
             // add folder replace some
-            CheckRunCompareFile(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed",
+            CheckRunCompareFile(new[] { "add", @"TestResults\TestAdd\packedFile.packed",
                 "--sourcePath", @"TestData\exampleFolder2\",
                 "--packedPath", "subfolder/" },
                 @"TestData\TestReferenceFiles\TestAdd\addFolderReplaceSome.packed",
@@ -121,13 +121,13 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
         public void TestRunAddFailed()
         {
             // add file missing
-            CheckRunFail(new[] { "add", "--packedFile", @"TestResults\TestAddFail\packedFile.packed",
+            CheckRunFail(new[] { "add", @"TestResults\TestAddFail\packedFile.packed",
                 "--sourcePath", "exampleFile_missing.txt",
                 "--packedPath", "file.txt"},
                 1, "Expected file not found");
 
             // add folder, folder not found
-            CheckRunFail(new[] { "add", "--packedFile", @"TestResults\TestAddFail\packedFile.packed",
+            CheckRunFail(new[] { "add", @"TestResults\TestAddFail\packedFile.packed",
                 "--sourcePath", "exampleFolder_missing/",
                 "--packedPath", "subfolder/"},
                 1, "Expected file not found");
@@ -137,7 +137,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             var fsFile = new FileStream(@"TestResults\TestAddFail\examplefile_readprotected.txt", FileMode.OpenOrCreate);
             try
             {
-                CheckRunFail(new[] { "add", "--packedFile", @"TestResults\TestAddFail\packedFile.packed",
+                CheckRunFail(new[] { "add", @"TestResults\TestAddFail\packedFile.packed",
                 "--sourcePath", "examplefile_readprotected.txt",
                 "--packedPath", "file.txt"},
                 1, "expected file not accessible");
@@ -155,7 +155,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
 
             try
             {
-            CheckRunFail(new[] { "add", "--packedFile", @"TestResults\TestAddFail\packedFile.packed",
+            CheckRunFail(new[] { "add", @"TestResults\TestAddFail\packedFile.packed",
                 "--sourcePath", "exampleFolder_readprotected/",
                 "--packedPath", "subfolder/"},
                 1, "expected some file not found");
@@ -175,14 +175,14 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             Directory.CreateDirectory(@"TestResults\TestRemove");
             File.Copy(@"TestData\example.packed", @"TestResults\TestRemove\packedFile.packed", true);
 
-            CheckRunCompareFile(new[] { "remove", "--packedFile" , @"TestResults\TestRemove\packedFile.packed",
+            CheckRunCompareFile(new[] { "remove", @"TestResults\TestRemove\packedFile.packed",
                 "--packedPath", "file1.txt"},
                 @"TestData\TestReferenceFiles\TestRemove\removedFile.packed",
                 @"TestResults\TestRemove\packedFile.packed",
                 "Remove file");
 
             File.Copy(@"TestData\example.packed", @"TestResults\TestRemove\packedFile.packed", true);
-            CheckRunCompareFile(new[] { "remove", "--packedFile" , @"TestResults\TestRemove\packedFile.packed",
+            CheckRunCompareFile(new[] { "remove", @"TestResults\TestRemove\packedFile.packed",
                 "--packedPath", "folder1/"},
                 @"TestData\TestReferenceFiles\TestRemove\removedFolder.packed",
                 @"TestResults\TestRemove\packedFile.packed",
@@ -198,12 +198,12 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             Directory.CreateDirectory(@"TestResults\TestRemove");
             File.Copy(@"TestData\example.packed", @"TestResults\TestRemove\packedFile.packed", true);
 
-            CheckRunFail(new[] { "remove", "--packedFile" , @"TestResults\TestRemove\packedFile.packed",
+            CheckRunFail(new[] { "remove", @"TestResults\TestRemove\packedFile.packed",
                 "--packedPath", "file_missing.txt"},
                 1, "Remove file does not exist");
 
             File.Copy(@"TestData\example.packed", @"TestResults\TestRemove\packedFile.packed", true);
-            CheckRunFail(new[] { "remove", "--packedFile" , @"TestResults\TestRemove\packedFile.packed",
+            CheckRunFail(new[] { "remove", @"TestResults\TestRemove\packedFile.packed",
                 "--packedPath", "folder_missing/"},
                 1, "Remove folder does not exist");
         }
@@ -214,7 +214,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             Directory.CreateDirectory(@"TestResults\TestRename");
 
             File.Copy(@"TestData\example.packed", @"TestResults\TestRename\packedFile.packed", true);
-            CheckRunCompareFile(new[] { "rename", "--packedFile" , @"TestResults\TestRename\packedFile.packed",
+            CheckRunCompareFile(new[] { "rename", @"TestResults\TestRename\packedFile.packed",
                 "--oldPackedPath", "file1.txt",
                 "--newPackedPath", "file_renamed.txt"},
                 @"TestData\TestReferenceFiles\TestRename\renameFile.packed",
@@ -222,7 +222,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "Rename file");
 
             File.Copy(@"TestData\example.packed", @"TestResults\TestRename\packedFile.packed", true);
-            CheckRunCompareFile(new[] { "rename", "--packedFile" , @"TestResults\TestRename\packedFile.packed",
+            CheckRunCompareFile(new[] { "rename", @"TestResults\TestRename\packedFile.packed",
                 "--oldPackedPath", "folder1/",
                 "--newPackedPath", "directory/"},
                 @"TestData\TestReferenceFiles\TestRename\renameFolder.packed",
@@ -230,7 +230,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "Rename folder");
 
             File.Copy(@"TestData\example.packed", @"TestResults\TestRename\packedFile.packed", true);
-            CheckRunCompareFile(new[] { "rename", "--packedFile" , @"TestResults\TestRename\packedFile.packed",
+            CheckRunCompareFile(new[] { "rename", @"TestResults\TestRename\packedFile.packed",
                 "--oldPackedPath", "/",
                 "--newPackedPath", "sub/"},
                 @"TestData\TestReferenceFiles\TestRename\renameRoot.packed",
@@ -244,13 +244,13 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             Directory.CreateDirectory(@"TestResults\TestRename");
 
             File.Copy(@"TestData\example.packed", @"TestResults\TestRename\packedFile.packed", true);
-            CheckRunFail(new[] { "rename", "--packedFile" , @"TestResults\TestRename\packedFile.packed",
+            CheckRunFail(new[] { "rename", @"TestResults\TestRename\packedFile.packed",
                 "--oldPackedPath", "file_missing.txt",
                 "--newPackedPath", "file_renamed.txt"},
                 1, "Rename missing file");
 
             File.Copy(@"TestData\example.packed", @"TestResults\TestRename\packedFile.packed", true);
-            CheckRunFail(new[] { "rename", "--packedFile" , @"TestResults\TestRename\packedFile.packed",
+            CheckRunFail(new[] { "rename", @"TestResults\TestRename\packedFile.packed",
                 "--oldPackedPath", "folder_missing/",
                 "--newPackedPath", "directory/"},
                 1, "Rename missing folder");
@@ -259,28 +259,28 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
         [TestMethod]
         public void TestRunExtract()
         {
-            CheckRunCompareFile(new[] { "extract", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareFile(new[] { "extract", @"TestData\example.packed",
                 "--packedPath", "file1.txt",
                 "--destinationPath", @"TestResults\TestExtract\file.txt"},
                 @"TestData\TestReferenceFiles\TestExtract\ExtractFile\file.txt",
                 @"TestResults\TestExtract\file.txt",
                 "Extract file");
 
-            CheckRunCompareFolder(new[] { "extract", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareFolder(new[] { "extract", @"TestData\example.packed",
                 "--packedPath", "folder1/",
                 "--destinationPath", @"TestResults\TestExtract\someFolder\"},
                 @"TestData\TestReferenceFiles\TestExtract\ExtractFolder\someFolder\",
                 @"TestResults\TestExtract\someFolder\",
                 "Extract folder");
 
-            CheckRunCompareFolder(new[] { "extract", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareFolder(new[] { "extract", @"TestData\example.packed",
                 "--packedPath", "folder2/folder1/file1.txt",
                 "--destinationPath", @"TestResults\TestExtract\ExtractFileToFolder\Output\"},
                 @"TestData\TestReferenceFiles\TestExtract\ExtractFileToFolder\Output\",
                 @"TestResults\TestExtract\ExtractFileToFolder\Output\",
                 "Extract file from folder to folder");
 
-            CheckRunCompareFolder(new[] { "extract", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareFolder(new[] { "extract", @"TestData\example.packed",
                 "--destinationPath", @"TestResults\TestExtract\all\"},
                 @"TestData\TestReferenceFiles\TestExtract\ExtractAll\",
                 @"TestResults\TestExtract\all\",
@@ -290,12 +290,12 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
         [TestMethod]
         public void TestRunExtractFailed()
         {           
-            CheckRunFail(new[] { "extract", "--packedFile", @"TestData\example.packed",
+            CheckRunFail(new[] { "extract", @"TestData\example.packed",
                 "--packedPath", "not_exsits.none",
                 "--destinationPath", @"TestResults\TestExtract\not_exists.none"},
                 1, "Extract nonexisting file");
 
-            CheckRunFail(new[] { "extract", "--packedFile", @"TestData\example.packed",
+            CheckRunFail(new[] { "extract", @"TestData\example.packed",
                 "--packedPath", "not_exsits/",
                 "--destinationPath", @"TestResults\TestExtract\all\"},
                 1, "Extract nonexisting folder");
@@ -304,7 +304,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             var fsFile = new FileStream(@"TestResults\TestExtract\file.txt", FileMode.OpenOrCreate);
             try
             {
-                CheckRunFail(new[] { "extract", "--packedFile", @"TestData\example.packed",
+                CheckRunFail(new[] { "extract", @"TestData\example.packed",
                 "--packedPath", "file1.txt",
                 "--destinationPath", @"TestResults\TestExtract\file.txt"},
                 1, "Destination path is unavilable");
@@ -318,12 +318,12 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
         [TestMethod]
         public void TestRunList()
         {
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\empty.packed" },
+            CheckRunCompareOutput(new[] { "list", @"TestData\empty.packed" },
                 "'TestData\\empty.packed' is empty.\r\n",
                 "List empty"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed" },
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed" },
                 "file1.txt\r\n" +
                 "file2.txt\r\n" +
                 "folder1/file1.txt\r\n" +
@@ -335,7 +335,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "List full"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--show-file-size"},
                 "file1.txt   Size: 102\r\n" +
                 "file2.txt   Size: 169\r\n" +
@@ -348,7 +348,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "List full filesizes"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--show-file-offset"},
                 "file1.txt   Offset: 244\r\n" +
                 "file2.txt   Offset: 346\r\n" +
@@ -361,7 +361,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "List full offsets"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--show-file-size", "--show-file-offset"},
                 "file1.txt   Size: 102   Offset: 244\r\n" +
                 "file2.txt   Size: 169   Offset: 346\r\n" +
@@ -374,13 +374,13 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "List full filesizes + offsets"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--searchString", "nothing"},
                 "Could not find anything by query 'nothing' in 'TestData\\example.packed'\r\n",
                 "List could not find"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--searchString", "1" },
                 "file1.txt\r\n" +
                 "folder1/file1.txt\r\n" +
@@ -391,21 +391,21 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "List 1"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--searchString", "file", "--starts-with" },
                 "file1.txt\r\n" +
                 "file2.txt\r\n",
                 "List file starts-width"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\TestReferenceFiles\TestList\listMatchFile.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\TestReferenceFiles\TestList\listMatchFile.packed",
                 "--searchString", "file1", "--match-filename" },
                 "file1.txt\r\n" +
                 "folder1/file1.txt\r\n",
                 "List match-filename"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--searchString", "*.txt" },
                 "file1.txt\r\n" +
                 "file2.txt\r\n" +
@@ -417,7 +417,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "List *.txt"
             );
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--searchString", "folder2/*.txt" },
                 "folder2/file1.txt\r\n" +
                 "folder2/file2.txt\r\n" +
@@ -425,7 +425,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "folder2/folder1/file2.txt\r\n",
                 "List folder2/*.txt");
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--searchString", @"folder2/.*\.txt", "--regex" },
                 "folder2/file1.txt\r\n" +
                 "folder2/file2.txt\r\n" +
@@ -434,7 +434,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "List folder2/.*\\.txt");
 
             // todo: tree output
-            //CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            //CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
             //    "--outputStyle", "Tree"},
             //    "│   file1.txt\r\n" +
             //    "│   file2.txt\r\n" +
@@ -452,7 +452,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             //    "            file2.txt\r\n",
             //    "List as tree");
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--outputStyle", "Name",
                 "--searchString", "folder2/" },
                 "file1.txt\r\n" +
@@ -461,7 +461,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "file2.txt\r\n",
                 "List files with only filename from folder2");
 
-            CheckRunCompareOutput(new[] { "list", "--packedFile", @"TestData\example.packed",
+            CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
                 "--outputStyle", "Name",
                 "--searchString", "folder2/",
                 "--show-file-size", "--show-file-offset"},
@@ -486,7 +486,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
         public void TestInputPackedFail()
         {
             // check uncorrect input
-            CheckRunFail(new[] {"add", "--packedFile", "/.,*&^$Q*",
+            CheckRunFail(new[] {"add", "/.,*&^$Q*",
                     "--sourcePath", @"TestData\examplefile1.txt",
                     "--packedPath", "file.txt"}, 1, "unable to create expected file");
 
@@ -499,7 +499,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             var fsFile = new FileStream(@"TestResults\TestInputPackedFail\packedFile.packed", FileMode.OpenOrCreate);
             try
             {
-                CheckRunFail(new[] {"add", "--packedFile", @"TestResults\TestInputPackedFail\packedFile.packed",
+                CheckRunFail(new[] {"add", @"TestResults\TestInputPackedFail\packedFile.packed",
                     "--sourcePath", @"TestData\examplefile1.txt",
                     "--packedPath", "file.txt"}, 1, "Expected file to be inaccessible");
             }
@@ -511,7 +511,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             }
 
             // check unreadable/invalid packed
-            CheckRunFail(new[] {"add", "--packedFile", @"TestResults\TestInputPackedFail\packedFile.packed",
+            CheckRunFail(new[] {"add", @"TestResults\TestInputPackedFail\packedFile.packed",
                 "--sourcePath", @"TestData\exampleFile1.txt",
                 "--packedPath", "file.txt"}, 1, "Expected packed file to be invalid");
 
@@ -527,7 +527,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
 
             // Access denied
             Directory.CreateDirectory(@"TestResults\TestOutputPackedFail\filenameWasTaken");
-            CheckRunFail(new[] { "add", "--packedFile", @"TestResults\TestOutputPackedFail\packedFile.packed",
+            CheckRunFail(new[] { "add", @"TestResults\TestOutputPackedFail\packedFile.packed",
                 "--sourcePath", @"TestData\examplefile1.txt",
                 "--packedPath", "folder/file.txt",
                 "--outputPackedFile", @"TestResults\TestOutputPackedFail\filenameWasTaken" },
@@ -539,7 +539,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             var fsFile = new FileStream(@"TestResults\TestOutputPackedFail\packedOutFile.packed", FileMode.OpenOrCreate);
             try
             {
-                CheckRunFail(new[] {"add", "--packedFile", @"TestResults\TestOutputPackedFail\packedFile.packed",
+                CheckRunFail(new[] {"add", @"TestResults\TestOutputPackedFail\packedFile.packed",
                     "--sourcePath", @"TestData\examplefile1.txt",
                     "--packedPath", "file.txt",
                     "--outputPackedFile", @"TestResults\TestOutputPackedFail\packedOutFile.packed" },
@@ -561,7 +561,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             File.Copy(@"TestData\empty.packed", @"TestResults\TestBackup\packedFile.packed", true);
             File.Copy(@"TestData\examplefile1.txt", @"TestResults\TestBackup\examplefile1.txt", true);
 
-            CheckRunCompareFile(new[] {"add", "--packedFile", @"TestResults\TestBackup\packedFile.packed",
+            CheckRunCompareFile(new[] {"add", @"TestResults\TestBackup\packedFile.packed",
                 "--sourcePath", @"TestData\examplefile1.txt",
                 "--packedPath", @"file.txt" },
                 @"TestResults\TestBackup\packedFile.packed.bak",
@@ -569,7 +569,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
                 "Backup after adding file to new"
             );
 
-            CheckRunCompareFile(new[] {"add", "--packedFile", @"TestResults\TestBackup\packedFile.packed",
+            CheckRunCompareFile(new[] {"add", @"TestResults\TestBackup\packedFile.packed",
                 "--sourcePath", @"TestData\examplefile1.txt",
                 "--packedPath", @"file.txt" },
                 @"TestResults\TestBackup\packedFile.packed.bak",
@@ -585,7 +585,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             //var fsFile = new FileStream(@"TestResults\TestBackup\examplefile1.txt", FileMode.Open);
             //try
             //{
-            //    CheckRunCompareFile(new[] {"extract", "--packedFile", @"TestResults\TestBackup\packedFile.packed",
+            //    CheckRunCompareFile(new[] {"extract", @"TestResults\TestBackup\packedFile.packed",
             //    "--destinationPath", @"TestResults\TestBackup\examplefile1.txt",
             //    "--packedPath", @"file.txt" },
             //    @"TestResults\TestBackup\examplefile1.txt",
@@ -598,7 +598,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             //    fsFile.Close();
             //}
 
-            CheckRunFileExists(new[] {"extract", "--packedFile", @"TestResults\TestBackup\packedFile.packed",
+            CheckRunFileExists(new[] {"extract", @"TestResults\TestBackup\packedFile.packed",
                 "--destinationPath", @"TestResults\TestBackup\examplefile1.txt",
                 "--packedPath", @"file.txt" },
                 @"TestResults\TestBackup\examplefile1.txt.bak",
@@ -609,12 +609,12 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             // Todo: implement check later
             /* // add file keep backup
             // (create dummy packedFile.packed.bak before call, expect to be unchanged)
-            CheckRun(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed", "--sourcePath", "'examplefile1.txt'", "--packedPath", "'folder/file.txt'", "--keepBackup" }, "", "");
+            CheckRun(new[] { "add", @"TestResults\TestAdd\packedFile.packed", "--sourcePath", "'examplefile1.txt'", "--packedPath", "'folder/file.txt'", "--keepBackup" }, "", "");
             // add file keep backup but overwrite old backup
-            CheckRun(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed", "--sourcePath", "'examplefile3.txt'", "--packedPath", "'folder/file.txt'", "--keepBackup", "--overwriteOldBackup" }, "", "");
+            CheckRun(new[] { "add", @"TestResults\TestAdd\packedFile.packed", "--sourcePath", "'examplefile3.txt'", "--packedPath", "'folder/file.txt'", "--keepBackup", "--overwriteOldBackup" }, "", "");
             // add file keep do not keep backup and old backup
             // (create dummy packedFile.packed.bak before call, expect to be unchanged)
-            CheckRun(new[] { "add", "--packedFile", @"TestResults\TestAdd\packedFile.packed", "--sourcePath", "'examplefile2.png'", "--packedPath", "'folder/file.png'", "--overwriteOldBackup" }, "", "");
+            CheckRun(new[] { "add", @"TestResults\TestAdd\packedFile.packed", "--sourcePath", "'examplefile2.png'", "--packedPath", "'folder/file.png'", "--overwriteOldBackup" }, "", "");
             */
 
             // todo: find a way to test MakeBackup(), RestoreBackup() and DeleteBackup()

--- a/ScrapPackedTests/TestCliApp.cs
+++ b/ScrapPackedTests/TestCliApp.cs
@@ -435,7 +435,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
 
             // todo: tree output
             //CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
-            //    "--outputStyle", "Tree"},
+            //    "--outputStyle", "tree"},
             //    "│   file1.txt\r\n" +
             //    "│   file2.txt\r\n" +
             //    "│   \r\n" +
@@ -453,7 +453,7 @@ namespace ch.romibi.Scrap.Packed.PackerLib.Tests
             //    "List as tree");
 
             CheckRunCompareOutput(new[] { "list", @"TestData\example.packed",
-                "--outputStyle", "Name",
+                "--outputStyle", "name",
                 "--searchString", "folder2/" },
                 "file1.txt\r\n" +
                 "file2.txt\r\n" +


### PR DESCRIPTION
- [x] Changed --packedFile to positional argument
- [x] Added ability to pass path to packed as first argument followed by verb. Example:
`$ ScrapPackedExplorerCli.exe example.packed list -xzq filename.txt -l name`
Original semantic is still supported
- [x] Changed default singleton parser to custom one. 
- [x] Enum values now case insensative and they printed in help text
- [x] Usage and example now in help text
